### PR TITLE
CHANGE(build): @W-18394257@ Update permissions check for release automation

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ github.token }}
-    permissions:
-      contents: write
     outputs:
       branch-name: ${{ steps.create-branch.outputs.branch_name }}
     steps:


### PR DESCRIPTION
Fixes an issue where a permissions check was failing from our automated release job. This check is not required now that we are directly calling the workflow, and the default permissions of the github token in the repo should be sufficient.