### PR TITLE
CHANGE: @W-19431438@ Update git2gus statusWhenClosed

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -20,5 +20,5 @@
         "BUG P3": "a3QEE000001n7Sn2AI"
     },
     "gusTitlePrefix": "[GitHub Issue]",
-    "statusWhenClosed": "FIXED"
+    "statusWhenClosed": "CLOSED"
 }


### PR DESCRIPTION
This PR:
- Updates the `statusWhenClosed` field to be "CLOSED" per instructions [here](https://lwc-gus-bot.herokuapp.com/#getting-started). This matches what other teams ([IDE Extensions](https://github.com/forcedotcom/salesforcedx-vscode/blob/bb3d80af6df78a4886ae2f6502fd6b46e36282d8/.git2gus/config.json#L36), [CLI](https://github.com/forcedotcom/cli/blob/b5217f1d3e6d2027969f6e1bfbb14aa36221db89/.git2gus/config.json#L6)) are doing in forcedotcom too. When an Issue in Git is closed it should close the corresponding WI in Gus.

Caveats:
- The Issue [must](https://salesforce-internal.slack.com/archives/CKNH4KL3B/p1676397393725509?thread_ts=1675793573.473109&cid=CKNH4KL3B) originate from the Github Issue that is being closed.
- This only goes GH -> Gus not Gus -> GH.
- Does not apply to closing PRs, only WIs.