### PR TITLE
NEW @W-19772057@ Integrated enhanced selectors into CLI

### DIFF
--- a/messages/config-command.md
+++ b/messages/config-command.md
@@ -40,6 +40,10 @@ We're continually improving Salesforce Code Analyzer. Tell us what you think! Gi
 
   <%= config.bin %> <%= command.id %> --rule-selector eslint:no-undef
 
+- Display any relevant configuration settings associated with PMD rules whose severity is 2 or 3:
+
+  <%= config.bin %> <%= command.id %> --rule-selector eslint:(2,3)
+
 - Load an existing configuration file called `existing-config.yml`, and then write the configuration to a new file called `new-config.yml`, the configuration state that is applicable to all rules that are relevant to the workspace located in the current folder:
 
   <%= config.bin %> <%= command.id %> --config-file ./existing-config.yml --workspace . --output-file ./subfolder-config.yml
@@ -74,13 +78,13 @@ If you specify `--workspace` but not `--target`, then all the files within your 
 
 # flags.rule-selector.summary
 
-Selection of rules, based on engine name, severity level, rule name, tag, or a combination of criteria separated by colons.
+Selection of rules, based on engine name, severity level, rule name, tag, or a combination of criteria separated by colons and commas, and grouped by parentheses.
 
 # flags.rule-selector.description
 
 Use the `--rule-selector` flag to display only the configuration associated with the rules based on specific criteria. You can select by engine, such as the rules associated with the "retire-js" or "eslint" engine. Or select by the severity of the rules, such as high or moderate. You can also select rules using tag values or rule names.
 
-You can combine different criteria using colons to further filter the list; the colon works as an intersection. For example, `--rule-selector eslint:Security` reduces the output to only contain the configuration state associated with the rules from the "eslint" engine that have the "Security" tag. To add multiple rule selectors together (a union), specify the `--rule-selector` flag multiple times, such as `--rule-selector eslint:Recommended --rule-selector retire-js:3`.
+You can further filter the list by combining different criteria using colons to represent logical AND, commas to represent logical OR, and parentheses to create groupings. For example, `--rule-selector pmd:(Performance,Security):2` reduces the output to onlycontain the configuration state associated with PMD rules that have the Performance or Security tag and a severity of 2. You may also specify the flag multiple times to OR multiple selectors together. For example, `--rule-selector Performance,Security` is equivalent to `--rule-selector Performance --rule-selector Security`.
 
 If you don't specify this flag, then the command uses the "all" rule selector.
 

--- a/messages/rules-command.md
+++ b/messages/rules-command.md
@@ -48,6 +48,10 @@ We're continually improving Salesforce Code Analyzer. Tell us what you think! Gi
 
     <%= config.bin %> <%= command.id %> --rule-selector eslint:3 --rule-selector retire-js:Recommended
 
+- List all the "pmd" engine rules that have a severity of moderate (3) or high (2) and the "Performance" tag.
+
+    <%= config.bin %> <%= command.id %> --rule-selector pmd:(2,3):Performance
+
 - Similar to the previous example, but apply the rule overrides and engine settings from the configuration file called `code-analyzer2.yml` in the current folder. If, for example, you changed the severity of an "eslint" rule from moderate (3) to high (2) in the configuration file, then that rule isn't listed:
 
     <%= config.bin %> <%= command.id %> --rule-selector eslint:3 --rule-selector retire-js:Recommended --config-file ./code-analyzer2.yml
@@ -96,7 +100,7 @@ Selection of rules, based on engine name, severity level, rule name, tag, or a c
 
 Use the `--rule-selector` flag to select the list of rules based on specific criteria. For example, you can select by engine, such as the rules associated with the "retire-js" or "eslint" engine. Or select by the severity of the rules, such as high or moderate. You can also select rules using tag values or rule names. Every rule has a name, which is unique within the scope of an engine. Most rules have tags, although it's not required. An example of a tag is "Recommended". 
 
-You can combine different criteria using colons to further filter the list; the colon works as an intersection. For example, `--rule-selector eslint:Security` lists rules associated only with the "eslint" engine that have the Security tag. The flag `--rule-selector eslint:Security:3` flag lists the "eslint" rules that have the Security tag and moderate severity (3). To add multiple rule selectors together (a union), specify the `--rule-selector` flag multiple times, such as `--rule-selector eslint:Recommended --rule-selector retire-js:3`.
+You can further filter the list by combining different criteria using colons to represent logical AND, commas to represent logical OR, and parentheses to create groupings. For example, `--rule-selector pmd:(Performance,Security):2` lists rules associated only with the "pmd" engine that have the Security or Performance tags and a high severity (2). You may also specify the flag multiple times to OR multiple selectors together. For example, `--rule-selector Performance,Security` is equivalent to `--rule-selector Performance --rule-selector Security`.
 
 Run `<%= config.bin %> <%= command.id %> --rule-selector all` to list the possible values for engine name, rule name, tags, and severity levels that you can use with this flag.
 

--- a/messages/run-command.md
+++ b/messages/run-command.md
@@ -36,6 +36,10 @@ We're continually improving Salesforce Code Analyzer. Tell us what you think! Gi
 
     <%= config.bin %> <%= command.id %> --rule-selector all
 
+- Analyze the files using only rules in the "pmd" engine with a severity of high (2) or moderate (3), and the "Performance" tag.
+
+    <%= config.bin %> <%= command.id %> --rule-selector pmd:(2,3):Performance
+
 - Analyze files using the recommended "retire-js" rules; target all the files in the folder "./other-source" and only the Apex class files (extension .cls) in the folder "./force-app":
 
     <%= config.bin %> <%= command.id %> --rule-selector retire-js:Recommended --target ./other-source --target ./force-app/**/*.cls
@@ -86,7 +90,7 @@ Selection of rules, based on engine name, severity level, rule name, tag, or a c
 
 Use the `--rule-selector` flag to select the list of rules to run based on specific criteria. For example, you can select by engine, such as the rules associated with the "retire-js" or "eslint" engine. Or select by the severity of the rules, such as high or moderate. You can also select rules using tag values or rule names. Every rule has a name, which is unique within the scope of an engine. Most rules have tags, although it's not required. An example of a tag is "Recommended".
 
-You can combine different criteria using colons to further filter the list; the colon works as an intersection. For example, `--rule-selector eslint:Security` runs rules associated only with the "eslint" engine that have the Security tag. The flag `--rule-selector eslint:Security:3` flag runs the "eslint" rules that have the Security tag and moderate severity (3). To add multiple rule selectors together (a union), specify the `--rule-selector` flag multiple times, such as `--rule-selector eslint:Recommended --rule-selector retire-js:3`.
+You can further filter the list by combining different criteria using colons to represent logical AND, commas to represent logical OR, and parentheses to create groupings. For example, `--rule-selector pmd:(Performance,Security):2` runs rules associated only with the "pmd" engine that have the Security or Performance tags and a high severity (2). You may also specify the flag multiple times to OR multiple selectors together. For example, `--rule-selector Performance,Security` is equivalent to `--rule-selector Performance --rule-selector Security`.
 
 Run `<%= config.bin %> code-analyzer rules --rule-selector all` to see the possible values for engine name, rule name, tags, and severity levels that you can use with this flag.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@oclif/core": "3.27.0",
-				"@salesforce/code-analyzer-core": "0.36.0",
+				"@salesforce/code-analyzer-core": "^0.38.0",
 				"@salesforce/code-analyzer-engine-api": "0.30.0",
 				"@salesforce/code-analyzer-eslint-engine": "0.34.0",
 				"@salesforce/code-analyzer-flow-engine": "0.27.0",
@@ -4821,9 +4821,9 @@
 			}
 		},
 		"node_modules/@salesforce/code-analyzer-core": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/@salesforce/code-analyzer-core/-/code-analyzer-core-0.36.0.tgz",
-			"integrity": "sha512-I0Ph/D2RAWmANbv2p988acr9dX1EJh6ZCl5z0juaHjdUMCxqdme+9UbJ1ZvrvAx7qt/t6bCmxlmw5q4pPurdHQ==",
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@salesforce/code-analyzer-core/-/code-analyzer-core-0.38.0.tgz",
+			"integrity": "sha512-yqIVS3tJFsC+tJaIN7WXbQHcjsb34rh3k+UZ+Kw93kDz/LBH8R+5BLH8JQck0Pagbp+5NhLTdWb269WJ0IPuHQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@salesforce/code-analyzer-engine-api": "0.30.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"bugs": "https://github.com/forcedotcom/code-analyzer/issues",
 	"dependencies": {
 		"@oclif/core": "3.27.0",
-		"@salesforce/code-analyzer-core": "0.36.0",
+		"@salesforce/code-analyzer-core": "0.38.0",
 		"@salesforce/code-analyzer-engine-api": "0.30.0",
 		"@salesforce/code-analyzer-eslint-engine": "0.34.0",
 		"@salesforce/code-analyzer-flow-engine": "0.27.0",

--- a/src/commands/code-analyzer/config.ts
+++ b/src/commands/code-analyzer/config.ts
@@ -1,5 +1,5 @@
 import {Flags, SfCommand} from '@salesforce/sf-plugins-core';
-import {ConfigAction, ConfigDependencies} from '../../lib/actions/ConfigAction';
+import {ConfigAction, ConfigDependencies, ConfigInput} from '../../lib/actions/ConfigAction';
 import {ConfigFileWriter} from '../../lib/writers/ConfigWriter';
 import {ConfigStyledYamlViewer} from '../../lib/viewers/ConfigViewer';
 import {ConfigActionSummaryViewer} from '../../lib/viewers/ActionSummaryViewer';
@@ -37,7 +37,6 @@ export default class ConfigCommand extends SfCommand<void> implements Displayabl
 			description: getMessage(BundleName.ConfigCommand, 'flags.rule-selector.description'),
 			char: 'r',
 			multiple: true,
-			delimiter: ',',
 			default: ["all"]
 		}),
 		'config-file': Flags.file({
@@ -61,7 +60,11 @@ export default class ConfigCommand extends SfCommand<void> implements Displayabl
 		const parsedFlags = (await this.parse(ConfigCommand)).flags;
 		const dependencies: ConfigDependencies = this.createDependencies(parsedFlags['output-file']);
 		const action: ConfigAction = ConfigAction.createAction(dependencies);
-		await action.execute(parsedFlags);
+		const configInput: ConfigInput = {
+			...parsedFlags,
+			'rule-selector': parsedFlags['rule-selector'].flatMap(s => s.split(' '))
+		};
+		await action.execute(configInput);
 	}
 
 	protected createDependencies(outputFile?: string): ConfigDependencies {

--- a/src/commands/code-analyzer/rules.ts
+++ b/src/commands/code-analyzer/rules.ts
@@ -39,7 +39,6 @@ export default class RulesCommand extends SfCommand<void> implements Displayable
 			description: getMessage(BundleName.RulesCommand, 'flags.rule-selector.description'),
 			char: 'r',
 			multiple: true,
-			delimiter: ',',
 			default: ["Recommended"]
 		}),
 		'config-file': Flags.file({
@@ -74,7 +73,7 @@ export default class RulesCommand extends SfCommand<void> implements Displayable
 		const rulesInput: RulesInput = {
 			'config-file': parsedFlags['config-file'],
 			'output-file': outputFiles,
-			'rule-selector': parsedFlags['rule-selector'],
+			'rule-selector': parsedFlags['rule-selector'].flatMap(s => s.split(' ')),
 			'workspace': parsedFlags['workspace'],
 			'target': parsedFlags['target']
 		};

--- a/src/commands/code-analyzer/run.ts
+++ b/src/commands/code-analyzer/run.ts
@@ -43,7 +43,6 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 			description: getMessage(BundleName.RunCommand, 'flags.rule-selector.description'),
 			char: 'r',
 			multiple: true,
-			delimiter: ',',
 			default: ["Recommended"]
 		}),
 		// === Flags pertaining to output ===
@@ -81,7 +80,7 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 		const runInput: RunInput = {
 			'config-file': parsedFlags['config-file'],
 			'output-file': parsedFlags['output-file'] ?? [],
-			'rule-selector': parsedFlags['rule-selector'],
+			'rule-selector': parsedFlags['rule-selector'].flatMap(s => s.split(' ')),
 			'workspace': parsedFlags['workspace'],
 			'severity-threshold': parsedFlags['severity-threshold'] === undefined ? undefined :
 				convertThresholdToEnum(parsedFlags['severity-threshold'].toLowerCase()),

--- a/src/lib/actions/RulesAction.ts
+++ b/src/lib/actions/RulesAction.ts
@@ -41,6 +41,8 @@ export class RulesAction {
 
 	public async execute(input: RulesInput): Promise<void> {
 		const config: CodeAnalyzerConfig = this.dependencies.configFactory.create(input['config-file']);
+		//console.log(`selectors: ${JSON.stringify(input["rule-selector"])}`);
+		//input["rule-selector"] = [input["rule-selector"].join(',')];
 		const logWriter: LogFileWriter = await LogFileWriter.fromConfig(config);
 		this.dependencies.actionSummaryViewer.viewPreExecutionSummary(logWriter.getLogDestination());
 		// We always add a Logger Listener to the appropriate listeners list, because we should Always Be Logging.
@@ -65,6 +67,7 @@ export class RulesAction {
 		// EngineProgressListeners should start listening right before we call Core's `.selectRules()` method, since
 		// that's when progress events can start being emitted.
 		this.dependencies.progressListeners.forEach(listener => listener.listen(core));
+		//console.log(`selectors 2: ${JSON.stringify(input['rule-selector'])}`);
 		const ruleSelection: RuleSelection = await core.selectRules(input["rule-selector"], selectOptions);
 		this.emitEngineTelemetry(ruleSelection, enginePlugins.flatMap(p => p.getAvailableEngineNames()));
 		// After Core is done running, the listeners need to be told to stop, since some of them have persistent UI elements

--- a/test/commands/code-analyzer/config.test.ts
+++ b/test/commands/code-analyzer/config.test.ts
@@ -36,9 +36,9 @@ describe('`code-analyzer config` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue]);
 		});
 
-		it('Can be supplied once with multiple comma-separated values', async () => {
-			const inputValue = ['abcde', 'defgh'];
-			await ConfigCommand.run(['--rule-selector', inputValue.join(',')]);
+		it('Can be supplied once with multiple space-separated values', async () => {
+			const inputValue = ['abc,(asdf:eee):de', 'de:fgh'];
+			await ConfigCommand.run(['--rule-selector', inputValue.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', inputValue);
 		});
@@ -51,10 +51,10 @@ describe('`code-analyzer config` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue1, inputValue2]);
 		});
 
-		it('Can be supplied multiple times with multiple comma-separated values each', async () => {
-			const inputValue1 = ['abcde', 'hijlk'];
+		it('Can be supplied multiple times with multiple space-separated values each', async () => {
+			const inputValue1 = ['ab,(qq:zz),cde', 'hijlk'];
 			const inputValue2 = ['defgh', 'mnopq'];
-			await ConfigCommand.run(['--rule-selector', inputValue1.join(','), '--rule-selector', inputValue2.join(',')]);
+			await ConfigCommand.run(['--rule-selector', inputValue1.join(' '), '--rule-selector', inputValue2.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', [...inputValue1, ...inputValue2]);
 		});

--- a/test/commands/code-analyzer/rules.test.ts
+++ b/test/commands/code-analyzer/rules.test.ts
@@ -47,9 +47,9 @@ describe('`code-analyzer rules` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue]);
 		});
 
-		it('Can be supplied once with multiple comma-separated values', async () => {
-			const inputValue = ['abcde', 'defgh'];
-			await RulesCommand.run(['--rule-selector', inputValue.join(',')]);
+		it('Can be supplied once with multiple space-separated values', async () => {
+			const inputValue = ['ab,cde', 'def:gh'];
+			await RulesCommand.run(['--rule-selector', inputValue.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', inputValue);
 		});
@@ -62,10 +62,10 @@ describe('`code-analyzer rules` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue1, inputValue2]);
 		});
 
-		it('Can be supplied multiple times with multiple comma-separated values each', async () => {
-			const inputValue1 = ['abcde', 'hijlk'];
-			const inputValue2 = ['defgh', 'mnopq'];
-			await RulesCommand.run(['--rule-selector', inputValue1.join(','), '--rule-selector', inputValue2.join(',')]);
+		it('Can be supplied multiple times with multiple space-separated values each', async () => {
+			const inputValue1 = ['ab,cde', 'hi:jlk'];
+			const inputValue2 = ['de:(a,b):fgh', 'mnopq'];
+			await RulesCommand.run(['--rule-selector', inputValue1.join(' '), '--rule-selector', inputValue2.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', [...inputValue1, ...inputValue2]);
 		});

--- a/test/commands/code-analyzer/run.test.ts
+++ b/test/commands/code-analyzer/run.test.ts
@@ -141,9 +141,9 @@ describe('`code-analyzer run` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue]);
 		});
 
-		it('Can be supplied once with multiple comma-separated values', async () => {
+		it('Can be supplied once with multiple space-separated values', async () => {
 			const inputValue = ['abcde', 'defgh'];
-			await RunCommand.run(['--rule-selector', inputValue.join(',')]);
+			await RunCommand.run(['--rule-selector', inputValue.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', inputValue);
 		});
@@ -156,10 +156,10 @@ describe('`code-analyzer run` tests', () => {
 			expect(receivedActionInput).toHaveProperty('rule-selector', [inputValue1, inputValue2]);
 		});
 
-		it('Can be supplied multiple times with multiple comma-separated values each', async () => {
+		it('Can be supplied multiple times with multiple space-separated values each', async () => {
 			const inputValue1 = ['abcde', 'hijlk'];
 			const inputValue2 = ['defgh', 'mnopq'];
-			await RunCommand.run(['--rule-selector', inputValue1.join(','), '--rule-selector', inputValue2.join(',')]);
+			await RunCommand.run(['--rule-selector', inputValue1.join(' '), '--rule-selector', inputValue2.join(' ')]);
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('rule-selector', [...inputValue1, ...inputValue2]);
 		});


### PR DESCRIPTION
A [pair](https://github.com/forcedotcom/code-analyzer-core/pull/363) of [pull requests](https://github.com/forcedotcom/code-analyzer-core/pull/365) in `code-analyzer-core` introduced a more robust system of rule selection wherein you can use comma, colons, and parentheses to select rules more finely. This pull request upgrades the CLI to the new version of `code-analyzer-core` and integrates support for the new syntax into the CLI.

Note: We had to stop using commas as a hardcoded delimiter to split the `--rule-selector` flag since commas could now be located inside of parenthesis-groups. However, the user will notice no change in behavior because of how the new syntax is handled. (i.e., `--rule-selector 2,3` is no longer split up into `2` and `3` at the CLI-level, but the core level will split them up instead and all will be well.)