### PR TITLE
RELEASE @W-19079373@ Prevent PR title injection in validate-pr workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,16 +18,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Verify PR Title
-        # Pass untrusted values (the PR title) via the environment rather than
-        # direct ${{ }} interpolation, so they are treated as data and cannot
-        # inject shell commands.
+        # Pass untrusted values (the PR title and branch refs) via the
+        # environment rather than direct ${{ }} interpolation, so they are
+        # treated as data and cannot inject shell commands.
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           title="$PR_TITLE"
           title_upper=$(echo "$title" | tr '[:lower:]' '[:upper:]')
           base_ref="$BASE_REF"
+          head_ref="$HEAD_REF"
 
           # Define regex patterns for different types of PR titles
           MAIN2DEV_REGEX="^MAIN2DEV[[:space:]]*:?[[:space:]]*@W-[[:digit:]]{8,9}@.*MERGING.+[[:digit:]]{1,2}\.[[:digit:]]{1,2}\.[[:digit:]]{1,2}.*"
@@ -35,7 +37,7 @@ jobs:
           PR_INTO_DEV_OR_RELEASE_REGEX="^(FIX|CHANGE|NEW)([[:space:]]*\([^)]+\))?[[:space:]]*:?[[:space:]]*@W-[[:digit:]]{8,9}@.+"
 
           # Validate PR title based on base_ref and head_ref
-          if [[ "$base_ref" == "dev" && "${{ startsWith(github.head_ref, 'm2d/') }}" == "true" ]]; then
+          if [[ "$base_ref" == "dev" && "$head_ref" == m2d/* ]]; then
             if [[ ! "$title_upper" =~ $MAIN2DEV_REGEX ]]; then
               echo "::error::Invalid PR title: '$title'. Please follow the format: Main2Dev @W-XXXXXXXX@ Merging.*\d+\.\d+\.\d+"
               exit 1
@@ -45,7 +47,7 @@ jobs:
               echo "::error::Invalid PR title: '$title'. Please follow the format: RELEASE @W-XXXXXXXX@ Summary"
               exit 1
             fi
-          elif [[ "$base_ref" == "dev" || "${{ startsWith(github.base_ref, 'release-') }}" == "true" ]]; then
+          elif [[ "$base_ref" == "dev" || "$base_ref" == release-* ]]; then
             if [[ ! "$title_upper" =~ $PR_INTO_DEV_OR_RELEASE_REGEX ]]; then
               echo "::error::Invalid PR title: '$title'. Please follow the format: FIX|CHANGE|NEW (__) @W-XXXXXXXX@ Summary"
               exit 1

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [edited, opened, reopened, synchronize]
 
+# Principle of least privilege: this workflow only needs to read repository
+# contents. Restricting the token limits the blast radius of any compromised step.
+permissions:
+  contents: read
+
 jobs:
   # We need to verify that the Pull Request's title matches the desired format.
   verify_pr_title:
@@ -13,10 +18,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Verify PR Title
+        # Pass untrusted values (the PR title) via the environment rather than
+        # direct ${{ }} interpolation, so they are treated as data and cannot
+        # inject shell commands.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          title="${{ github.event.pull_request.title }}"
+          title="$PR_TITLE"
           title_upper=$(echo "$title" | tr '[:lower:]' '[:upper:]')
-          base_ref="${{ github.base_ref }}"
+          base_ref="$BASE_REF"
 
           # Define regex patterns for different types of PR titles
           MAIN2DEV_REGEX="^MAIN2DEV[[:space:]]*:?[[:space:]]*@W-[[:digit:]]{8,9}@.*MERGING.+[[:digit:]]{1,2}\.[[:digit:]]{1,2}\.[[:digit:]]{1,2}.*"


### PR DESCRIPTION
Hardens the validate-pr GitHub Actions workflow against PR-title script injection (CWE-94) by passing the untrusted PR title and base ref through environment variables instead of inline ${{ }} interpolation, and adds a least-privilege 'permissions: contents: read' block.

CI-only change (.github/workflows/validate-pr.yml); no runtime/package changes. Port of the fix already merged to dev (#2077) onto main.

Fixes W-19079373.