### PR TITLE
NEW @W-23659201@ Register uibundle engine in CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@salesforce/code-analyzer-regex-engine": "0.39.0",
 				"@salesforce/code-analyzer-retirejs-engine": "0.38.0",
 				"@salesforce/code-analyzer-sfge-engine": "0.24.0",
+				"@salesforce/code-analyzer-uibundle-engine": "0.2.0",
 				"@salesforce/core": "8.23.4",
 				"@salesforce/sf-plugins-core": "^12.2.26",
 				"@salesforce/ts-types": "^2.0.12",
@@ -5825,6 +5826,73 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-uibundle-engine": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@salesforce/code-analyzer-uibundle-engine/-/code-analyzer-uibundle-engine-0.2.0.tgz",
+			"integrity": "sha512-n2w9PW65cxZ9u2O6GzyEgaS/FDhdpmwWXJNPAywoZAZ9rfxYamZq8t2K3xjt8G0SjJQopUvTt49djjwjpNe4DQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/parser": "^7.25.0",
+				"@babel/traverse": "^7.25.0",
+				"@babel/types": "^7.25.0",
+				"@jridgewell/sourcemap-codec": "^1.5.5",
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"@salesforce/code-analyzer-engine-api": "0.42.0",
+				"@types/node": "^20.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-uibundle-engine/node_modules/@salesforce/code-analyzer-engine-api": {
+			"version": "0.42.0",
+			"resolved": "https://registry.npmjs.org/@salesforce/code-analyzer-engine-api/-/code-analyzer-engine-api-0.42.0.tgz",
+			"integrity": "sha512-ojS09MCnBMecPFdz0RIOCCbutL15HRwOlXzb0Mdgs8EAwAWnouxXpolUGIFhRh3Kd1sc56XOQrxBaxVfKXmFaQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/node": "^20.0.0",
+				"minimatch": "^10.2.6"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-uibundle-engine/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-uibundle-engine/node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-uibundle-engine/node_modules/minimatch": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.8"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@salesforce/core": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@salesforce/code-analyzer-regex-engine": "0.39.0",
 		"@salesforce/code-analyzer-retirejs-engine": "0.38.0",
 		"@salesforce/code-analyzer-sfge-engine": "0.24.0",
-		"@salesforce/code-analyzer-uibundle-engine": "0.1.0",
+		"@salesforce/code-analyzer-uibundle-engine": "0.2.0",
 		"@salesforce/core": "8.23.4",
 		"@salesforce/sf-plugins-core": "^12.2.26",
 		"@salesforce/ts-types": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@salesforce/code-analyzer-regex-engine": "0.39.0",
 		"@salesforce/code-analyzer-retirejs-engine": "0.38.0",
 		"@salesforce/code-analyzer-sfge-engine": "0.24.0",
+		"@salesforce/code-analyzer-uibundle-engine": "0.1.0-SNAPSHOT",
 		"@salesforce/core": "8.23.4",
 		"@salesforce/sf-plugins-core": "^12.2.26",
 		"@salesforce/ts-types": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@salesforce/code-analyzer-regex-engine": "0.39.0",
 		"@salesforce/code-analyzer-retirejs-engine": "0.38.0",
 		"@salesforce/code-analyzer-sfge-engine": "0.24.0",
-		"@salesforce/code-analyzer-uibundle-engine": "0.1.0-SNAPSHOT",
+		"@salesforce/code-analyzer-uibundle-engine": "0.1.0",
 		"@salesforce/core": "8.23.4",
 		"@salesforce/sf-plugins-core": "^12.2.26",
 		"@salesforce/ts-types": "^2.0.12",

--- a/src/lib/factories/EnginePluginsFactory.ts
+++ b/src/lib/factories/EnginePluginsFactory.ts
@@ -6,6 +6,7 @@ import * as RegexEngineModule from '@salesforce/code-analyzer-regex-engine';
 import * as FlowEngineModule from '@salesforce/code-analyzer-flow-engine';
 import * as SfgeEngineModule from '@salesforce/code-analyzer-sfge-engine';
 import * as ApexGuruEngineModule from '@salesforce/code-analyzer-apexguru-engine';
+import * as UIBundleEngineModule from '@salesforce/code-analyzer-uibundle-engine';
 
 export interface EnginePluginsFactory {
 	create(): EnginePlugin[];
@@ -20,7 +21,8 @@ export class EnginePluginsFactoryImpl implements EnginePluginsFactory {
 			RegexEngineModule.createEnginePlugin(),
 			FlowEngineModule.createEnginePlugin(),
 			SfgeEngineModule.createEnginePlugin(),
-			ApexGuruEngineModule.createEnginePlugin()
+			ApexGuruEngineModule.createEnginePlugin(),
+			UIBundleEngineModule.createEnginePlugin()
 		];
 	}
 }

--- a/test/lib/factories/EnginePluginsFactory.test.ts
+++ b/test/lib/factories/EnginePluginsFactory.test.ts
@@ -6,7 +6,7 @@ describe('EnginePluginsFactoryImpl', () => {
 		const pluginsFactory = new EnginePluginsFactoryImpl();
 		const enginePlugins = pluginsFactory.create();
 
-		expect(enginePlugins).toHaveLength(7);
+		expect(enginePlugins).toHaveLength(8);
 		expect(enginePlugins[0].getAvailableEngineNames()).toEqual(['eslint']);
 		expect(enginePlugins[1].getAvailableEngineNames()).toEqual(['pmd', 'cpd']);
 		expect(enginePlugins[2].getAvailableEngineNames()).toEqual(['retire-js']);
@@ -14,5 +14,6 @@ describe('EnginePluginsFactoryImpl', () => {
 		expect(enginePlugins[4].getAvailableEngineNames()).toEqual(['flow']);
 		expect(enginePlugins[5].getAvailableEngineNames()).toEqual(['sfge']);
 		expect(enginePlugins[6].getAvailableEngineNames()).toEqual(['apexguru']);
+		expect(enginePlugins[7].getAvailableEngineNames()).toEqual(['uibundle']);
 	});
 });


### PR DESCRIPTION
## Summary
Registers `@salesforce/code-analyzer-uibundle-engine` in the CLI's `EnginePluginsFactoryImpl` so the new UI Bundle engine runs by default with `sf code-analyzer run`.

## Changes
- `src/lib/factories/EnginePluginsFactory.ts` — import `UIBundleEngineModule` and add `UIBundleEngineModule.createEnginePlugin()` to the returned array.
- `package.json` — add `"@salesforce/code-analyzer-uibundle-engine": "0.1.0-SNAPSHOT"` to dependencies.

## Test plan
- [ ] `npm install && npm run build` — will only succeed after the engine is published (see companion PR).
- [ ] `npm test` — verify engine listing shows `uibundle` alongside the other engines.

## Companion PR
forcedotcom/code-analyzer-core#499 — the engine implementation. This PR depends on that one being merged **and** the resulting package being published before CI here can go green.

## Release-alignment note
The new engine pins `@salesforce/code-analyzer-engine-api@0.42.0-SNAPSHOT`; the CLI currently pins `0.39.0`. At publish time, the CLI's `engine-api` pin will need to move to match (or the engine must be published against a `0.39.x` line). Not blocking this PR's draft state; blocking the actual CLI cut.

## Related
- Work item: W-23659201